### PR TITLE
Add Quill based rich editor

### DIFF
--- a/helloludi/public/css/rich-editor.css
+++ b/helloludi/public/css/rich-editor.css
@@ -1,0 +1,29 @@
+/* Basic styling for the rich editor */
+#richEditor {
+    position: relative;
+}
+
+.editor-hover-button {
+    position: absolute;
+    z-index: 10;
+    background: #ffffff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    display: none;
+}
+
+.rich-editor-container:hover .editor-hover-button {
+    display: block;
+}
+
+.ql-container {
+    min-height: 300px;
+}
+
+/* Fonts for Quill */
+.ql-font-quicksand { font-family: 'Quicksand', sans-serif; }
+.ql-font-montserrat { font-family: 'Montserrat', sans-serif; }
+.ql-font-poppins { font-family: 'Poppins', sans-serif; }

--- a/helloludi/public/js/RichEditor.js
+++ b/helloludi/public/js/RichEditor.js
@@ -1,0 +1,201 @@
+class RichEditor {
+    constructor(containerId, options = {}) {
+        this.containerId = containerId;
+        this.options = options;
+        this.hiddenFieldId = options.hiddenFieldId || null;
+        this.quill = null;
+        this.hoverButton = null;
+        this.currentElement = null;
+        this.init();
+    }
+
+    init() {
+        const container = document.getElementById(this.containerId);
+        if (!container) return;
+
+        // Initialize Quill
+        const toolbarSelector = '#' + this.containerId + '-toolbar';
+        this.quill = new Quill(container.querySelector('.editor-content'), {
+            modules: {
+                toolbar: toolbarSelector
+            },
+            theme: 'snow'
+        });
+
+        // Load content from hidden field
+        const hidden = document.getElementById(this.hiddenFieldId);
+        if (hidden && hidden.value) {
+            this.quill.root.innerHTML = hidden.value;
+        }
+
+        this.quill.on('text-change', () => this.updateHiddenField());
+
+        this.setupHoverButton(container);
+        this.setupToolbarHandlers();
+    }
+
+    updateHiddenField() {
+        if (!this.hiddenFieldId) return;
+        const hidden = document.getElementById(this.hiddenFieldId);
+        if (hidden) hidden.value = this.quill.root.innerHTML;
+    }
+
+    setupToolbarHandlers() {
+        const toolbar = this.quill.getModule('toolbar');
+        toolbar.addHandler('image', () => this.showImageModal());
+        toolbar.addHandler('video', () => this.showVideoModal());
+        toolbar.addHandler('link', () => this.showLinkModal());
+        toolbar.addHandler('table', () => this.showTableModal());
+        toolbar.addHandler('hr', () => this.insertHorizontalRule());
+    }
+
+    setupHoverButton(container) {
+        const btn = document.createElement('button');
+        btn.className = 'editor-hover-button';
+        btn.type = 'button';
+        btn.textContent = '⚙';
+        container.appendChild(btn);
+        this.hoverButton = btn;
+
+        container.addEventListener('mouseover', (e) => {
+            const el = e.target;
+            if (['IMG', 'IFRAME', 'TABLE'].includes(el.tagName)) {
+                const rect = el.getBoundingClientRect();
+                const parentRect = container.getBoundingClientRect();
+                btn.style.top = (rect.top - parentRect.top + container.scrollTop) + 'px';
+                btn.style.left = (rect.left - parentRect.left + container.scrollLeft + rect.width - 20) + 'px';
+                btn.style.display = 'block';
+                btn.dataset.type = el.tagName.toLowerCase();
+                this.currentElement = el;
+            }
+        });
+
+        container.addEventListener('mouseleave', () => {
+            btn.style.display = 'none';
+            this.currentElement = null;
+        });
+
+        btn.addEventListener('click', () => {
+            const type = btn.dataset.type;
+            if (type === 'img') this.showImageModal(this.currentElement);
+            else if (type === 'iframe') this.showVideoModal(this.currentElement);
+            else if (type === 'table') this.showTableModal(this.currentElement);
+        });
+    }
+
+    showImageModal(el) {
+        const modalEl = document.getElementById('imageModal');
+        if (!modalEl) return;
+        const input = modalEl.querySelector('input');
+        input.value = el ? el.getAttribute('src') : '';
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+        modalEl.querySelector('.insert-image-btn').onclick = () => {
+            const url = input.value.trim();
+            if (url) {
+                if (el) {
+                    el.setAttribute('src', url);
+                } else {
+                    this.insertImage(url);
+                }
+            }
+            modal.hide();
+        };
+    }
+
+    showVideoModal(el) {
+        const modalEl = document.getElementById('videoModal');
+        if (!modalEl) return;
+        const input = modalEl.querySelector('input');
+        input.value = el ? el.getAttribute('src') : '';
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+        modalEl.querySelector('.insert-video-btn').onclick = () => {
+            const url = input.value.trim();
+            if (url) {
+                if (el) {
+                    el.setAttribute('src', url);
+                } else {
+                    this.insertVideo(url);
+                }
+            }
+            modal.hide();
+        };
+    }
+
+    showLinkModal() {
+        const modalEl = document.getElementById('linkModal');
+        if (!modalEl) return;
+        const input = modalEl.querySelector('input');
+        input.value = '';
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+        modalEl.querySelector('.insert-link-btn').onclick = () => {
+            const url = input.value.trim();
+            if (url) {
+                let range = this.quill.getSelection();
+                if (range) {
+                    this.quill.format('link', url);
+                }
+            }
+            modal.hide();
+        };
+    }
+
+    showTableModal(el) {
+        const modalEl = document.getElementById('tableModal');
+        if (!modalEl) return;
+        const rowsInput = modalEl.querySelector('input[name="rows"]');
+        const colsInput = modalEl.querySelector('input[name="cols"]');
+        rowsInput.value = '2';
+        colsInput.value = '2';
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+        modalEl.querySelector('.insert-table-btn').onclick = () => {
+            const rows = parseInt(rowsInput.value, 10) || 2;
+            const cols = parseInt(colsInput.value, 10) || 2;
+            if (el) {
+                // simple rebuild
+                el.innerHTML = this.buildTableBody(rows, cols);
+            } else {
+                this.insertTable(rows, cols);
+            }
+            modal.hide();
+        };
+    }
+
+    buildTableBody(rows, cols) {
+        let html = '';
+        for (let r = 0; r < rows; r++) {
+            html += '<tr>';
+            for (let c = 0; c < cols; c++) {
+                html += '<td>&nbsp;</td>';
+            }
+            html += '</tr>';
+        }
+        return html;
+    }
+
+    insertImage(url) {
+        const range = this.quill.getSelection(true);
+        this.quill.insertEmbed(range.index, 'image', url, Quill.sources.USER);
+    }
+
+    insertVideo(url) {
+        const range = this.quill.getSelection(true);
+        this.quill.insertEmbed(range.index, 'video', url, Quill.sources.USER);
+    }
+
+    insertTable(rows, cols) {
+        let table = '<table class="table table-bordered">' + this.buildTableBody(rows, cols) + '</table>';
+        const range = this.quill.getSelection(true);
+        this.quill.clipboard.dangerouslyPasteHTML(range.index, table);
+    }
+
+    insertHorizontalRule() {
+        const range = this.quill.getSelection(true);
+        this.quill.clipboard.dangerouslyPasteHTML(range.index, '<hr>');
+    }
+}
+
+window.RichEditor = RichEditor;

--- a/helloludi/templates/base.html.twig
+++ b/helloludi/templates/base.html.twig
@@ -13,6 +13,7 @@
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;700&family=Poppins:wght@300;700&display=swap" rel="stylesheet">
         <link rel='stylesheet'
               href='https://cdn-uicons.flaticon.com/2.6.0/uicons-regular-straight/css/uicons-regular-straight.css'>
 

--- a/helloludi/templates/components/_editor_modals.html.twig
+++ b/helloludi/templates/components/_editor_modals.html.twig
@@ -1,0 +1,72 @@
+<div class="modal fade" id="imageModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Insérer une image</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="text" class="form-control" placeholder="URL de l'image">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary insert-image-btn">Insérer</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="videoModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Insérer une vidéo</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="text" class="form-control" placeholder="URL de la vidéo">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary insert-video-btn">Insérer</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="linkModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Insérer un lien</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="text" class="form-control" placeholder="URL du lien">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary insert-link-btn">Insérer</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="tableModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Insérer un tableau</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body d-flex gap-2">
+                <input type="number" name="rows" class="form-control" placeholder="Lignes" min="1" value="2">
+                <input type="number" name="cols" class="form-control" placeholder="Colonnes" min="1" value="2">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary insert-table-btn">Insérer</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/helloludi/templates/components/_editor_modals_optimized.html.twig
+++ b/helloludi/templates/components/_editor_modals_optimized.html.twig
@@ -1,0 +1,1 @@
+{% include 'components/_editor_modals.html.twig' %}

--- a/helloludi/templates/components/_editor_toolbar.html.twig
+++ b/helloludi/templates/components/_editor_toolbar.html.twig
@@ -1,0 +1,45 @@
+<div id="{{ toolbar_id|default('richEditor-toolbar') }}" class="editor-toolbar">
+    <span class="ql-formats">
+        <select class="ql-font">
+            <option selected></option>
+            <option value="quicksand">Quicksand</option>
+            <option value="montserrat">Montserrat</option>
+            <option value="poppins">Poppins</option>
+        </select>
+        <select class="ql-header">
+            <option selected></option>
+            <option value="1">H1</option>
+            <option value="2">H2</option>
+            <option value="3">H3</option>
+            <option value="4">H4</option>
+            <option value="5">H5</option>
+        </select>
+    </span>
+    <span class="ql-formats">
+        <button class="ql-bold"></button>
+        <button class="ql-italic"></button>
+        <button class="ql-underline"></button>
+        <button class="ql-strike"></button>
+    </span>
+    <span class="ql-formats">
+        <button class="ql-list" value="ordered"></button>
+        <button class="ql-list" value="bullet"></button>
+    </span>
+    <span class="ql-formats">
+        <button class="ql-align" value=""></button>
+        <button class="ql-align" value="center"></button>
+        <button class="ql-align" value="right"></button>
+        <button class="ql-align" value="justify"></button>
+    </span>
+    <span class="ql-formats">
+        <button class="ql-blockquote"></button>
+        <button class="ql-code-block"></button>
+        <button class="ql-insertHR">HR</button>
+    </span>
+    <span class="ql-formats">
+        <button class="ql-link"></button>
+        <button class="ql-image"></button>
+        <button class="ql-video"></button>
+        <button class="ql-table">Tbl</button>
+    </span>
+</div>

--- a/helloludi/templates/components/_rich_editor_optimized.html.twig
+++ b/helloludi/templates/components/_rich_editor_optimized.html.twig
@@ -1,0 +1,13 @@
+<div class="form-group">
+    <label class="form-label">
+        <i class="bi bi-pencil-square"></i>
+        Contenu
+    </label>
+    <div class="rich-editor-container" id="richEditor">
+        {% include 'components/_editor_toolbar.html.twig' with { 'toolbar_id': 'richEditor-toolbar' } %}
+        <div class="editor-content" contenteditable="true" id="editorContent">
+            {{ content|raw }}
+        </div>
+    </div>
+    <textarea style="display:none;" id="hiddenContent" name="{{ field_name }}">{{ content|raw }}</textarea>
+</div>

--- a/helloludi/templates/post/create.html.twig
+++ b/helloludi/templates/post/create.html.twig
@@ -2,8 +2,9 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.0/font/bootstrap-icons.min.css"
-          rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.0/font/bootstrap-icons.min.css"
+      rel="stylesheet">
+<link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
     <style>
         /* Styles pour moderniser le formulaire */
         .form-container {
@@ -652,6 +653,7 @@
 
 {% block javascripts %}
     {{ parent() }}
+    <script src="https://cdn.quilljs.com/1.3.7/quill.js"></script>
     <script src="{{ asset('js/RichEditor.js') }}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {

--- a/helloludi/templates/post/edit.html.twig
+++ b/helloludi/templates/post/edit.html.twig
@@ -4,6 +4,7 @@
     {{ parent() }}
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.0/font/bootstrap-icons.min.css"
           rel="stylesheet">
+<link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
     <style>
         /* Styles pour moderniser le formulaire */
         .form-container {
@@ -667,6 +668,7 @@
 
 {% block javascripts %}
     {{ parent() }}
+    <script src="https://cdn.quilljs.com/1.3.7/quill.js"></script>
     <script src="{{ asset('js/RichEditor.js') }}"></script>
     <script>
         let editorInstance = null;


### PR DESCRIPTION
## Summary
- provide Quill-powered RichEditor and dedicated modals
- style toolbar and hover button
- include components for toolbar and modals
- integrate RichEditor in post forms
- load additional fonts

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849473e8d8483209f495ee13a5dfe98